### PR TITLE
fix ending tar parse stream early

### DIFF
--- a/lib/clone.js
+++ b/lib/clone.js
@@ -76,20 +76,9 @@ function clone(pkg, src, dst, credentials, xform, ready) {
         data.pipe(concat(attachReadme))
           .on('error', onerror)
       }
-
-      function attachReadme(data) {
-        metadata.readme = data.toString()
-        parse.end()
-      }
     })
 
-    parse.on('end', function() {
-      if(setup) {
-        return publishPackage()
-      }
-
-      parsed = true
-    })
+    parse.on('end', onParseEnd)
 
     tarball
       .pipe(zlib.createGunzip())
@@ -102,6 +91,21 @@ function clone(pkg, src, dst, credentials, xform, ready) {
     })
     tarball.pipe(concat(ontarball))
       .on('error', onerror)
+
+    function attachReadme(data) {
+      metadata.readme = data.toString()
+      parse.pause()
+
+      onParseEnd()
+    }
+
+    function onParseEnd() {
+      if(setup) {
+        return publishPackage()
+      }
+
+      parsed = true
+    }
   }
 
   function ontarball(tarballData) {


### PR DESCRIPTION
calling end directly on the parse stream occasionally throws parse errors.