### PR TITLE
Fix ability to clone scoped packages

### DIFF
--- a/lib/clone.js
+++ b/lib/clone.js
@@ -1,9 +1,11 @@
-var concat = require('concat-stream')
+var querystring = require('querystring')
+  , concat = require('concat-stream')
   , request = require('hyperquest')
   , fetch = require('npm-fetch')
   , through = require('through')
   , tar = require('tar-stream')
   , crypto = require('crypto')
+  , pacote = require('pacote')
   , zlib = require('zlib')
   , url = require('url')
 
@@ -33,7 +35,9 @@ function clone(pkg, src, dst, options, ready) {
     , metadata
     , publish
 
-  var originalTarball = fetch(pkg.name, pkg.version, {registry: src})
+  var originalTarball = (/^@/.test(pkg.name || '')
+      ? pacote.tarball.stream(pkg.name + '@' + pkg.version, {registry: src})
+      : fetch(pkg.name, pkg.version, {registry: src}))
     .on('error', onerror)
 
   var gzipStream = transformedTarball
@@ -163,7 +167,7 @@ function clone(pkg, src, dst, options, ready) {
   function publishPackage(content) {
     content = JSON.stringify(createMetadata(content))
     publish = request.put(
-        url.resolve(dst, pkg.name)
+        url.resolve(dst, querystring.escape(pkg.name))
       , {headers: buildHeaders(options, content)}
     )
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "minimist": "^1.1.0",
     "npm": "^2.5.1",
     "npm-fetch": "^0.0.9",
+    "pacote": "^7.0.2",
     "semver": "^4.3.0",
     "tape": "^3.5.0",
     "tar-stream": "^1.1.2",

--- a/test/clone.js
+++ b/test/clone.js
@@ -5,6 +5,7 @@ var clone = require('../index.js')
 
 module.exports = function testClone() {
   test('clone module', cloneModule)
+  test('clone scoped module', cloneScoped)
   test('clone version', cloneVersion)
   test('should not blow up if cloning the same thing twice', cloneTwice)
 }
@@ -34,6 +35,37 @@ function cloneModule(t) {
       t.equal(data.meta.name, 'unpm', 'should have correct metadata')
       t.ok(data.json, 'should have found package.json')
       t.equal(data.json.name, 'unpm', 'should have same name in package.json')
+      t.equal(
+          data.json.version
+        , data.meta['dist-tags'].latest
+        , 'should match version in package.json'
+      )
+      reg.server.close(t.end.bind(t))
+    }
+  })
+}
+
+function cloneScoped(t) {
+  helpers.createRegistry(function gotReg(reg, port) {
+    var packageJSON = null
+      , version
+
+    clone(
+        '@kgryte/noop'
+      , 'http://registry.npmjs.org'
+      , 'http://localhost:' + port
+      , function done(err) {
+          t.notOk(err)
+          helpers.getData('unpm', null, reg, finish)
+        }
+    )
+
+    function finish(err, data) {
+      t.notOk(err, 'should not error')
+      t.ok(data, 'should get data')
+      t.equal(data.meta.name, '@kgryte/noop', 'should have correct metadata')
+      t.ok(data.json, 'should have found package.json')
+      t.equal(data.json.name, '@kgryte/noop', 'same name in package.json')
       t.equal(
           data.json.version
         , data.meta['dist-tags'].latest


### PR DESCRIPTION
This fixes a bug where attempting to clone public, scoped packages (e.g. `@kgryte/noop`) would error out.

There are two issues here: 1) npm-fetch seems not to handle scoped packages well, %-encoding just the @.  This leads to errors like:

    $ bin/clone-packages -t http://localhost:8123/ @kgryte/noop
    cloning @kgryte/noop @ *...
    Error: Not found : %40kgryte/noop

2) when this module PUTs the module on the destination registry, it skips %-encoding the name, leading to 404s due to the scope being treated as a URL path.

I initially tried to update npm-fetch, but it hasn't been updated in a long time.  The npm-registry-client it uses is ancient, but porting to a newer version isn't trivial since the API has changed, and I wasn't sure exactly how to update the callers to handle all cases properly.

So, I added a new alternative for npm-fetch, pacote, here instead.  I make use of it conditionally, only for this case where npm-fetch fails.  It'd clean things up to replace npm-fetch with pacote entirely, but I wasn't sure it covers all of the same use cases in the same way.

This also adds a test for the new functionality.  Unfortunately, I couldn't get the tests to pass on master, and I don't have a lot of time to figure out why.  So I blindly added a test for scoped clones, which I *think* should cover this case just fine.

Let me know if this passes muster, or if I'm barking up the wrong tree.  Thanks!